### PR TITLE
BUGFIX: Fixed A File Descriptor Leak Related Bug

### DIFF
--- a/heat.py
+++ b/heat.py
@@ -51,7 +51,8 @@ class PyHeatMagic(Magics):
         if filename is not None:
             filename = os.path.expanduser(args.out)
 
-        _, tmp_file = mkstemp()
+        fd, tmp_file = mkstemp()
+        os.close(fd)
         with open(tmp_file, 'wb') as f:
             f.write(cell.encode())
 


### PR DESCRIPTION
## Overview
This PR fixes a file descriptor leak related bug in `heat.py` file. The calling of `mkstemp()` returns a random temp file name and a file descriptor. It becomes the responsibility of the user to close that file descriptor. Having too much of open file descriptors leads to an `OSError [Errno 24]`.

## PoC
```python
from tempfile import mkstemp
import os

def heat():
        _, tmp_file = mkstemp()
        with open(tmp_file, "w") as f:
                f.write("foo")
        # do something
        os.remove(tmp_file)

if __name__ == "__main__":
        for i in range(100_000):
                print(i+1)
                heat()
```
Running the above program gives the output:
```
...
1019
1020
1021
Traceback (most recent call last):
  File "/mnt/f/GitHub/test_pyheat.py", line 17, in <module>
  File "/mnt/f/GitHub/test_pyheat.py", line 7, in heat
OSError: [Errno 24] Too many open files: '/tmp/tmp3h57izmy'
```
